### PR TITLE
e2e-owners-3523f1b-3486227679864df8b5712f93bc48e090-an-owners-file-is-submitted-by-redhat

### DIFF
--- a/charts/redhat/redhat/missing-prefix-3486227679864df8b5712f93bc48e090-1/OWNERS
+++ b/charts/redhat/redhat/missing-prefix-3486227679864df8b5712f93bc48e090-1/OWNERS
@@ -1,0 +1,10 @@
+chart:
+  name: missing-prefix-3486227679864df8b5712f93bc48e090-1
+  shortDescription: Test chart for testing chart submission workflows.
+publicPgpKey: null
+providerDelivery: false
+users:
+- githubUsername: jsm84
+vendor:
+  label: redhat
+  name: "Red Hat"


### PR DESCRIPTION
Test triggered by https://github.com/jsm84/openshift-helm-charts-dev/pull/1.