### PR TITLE
e2e-owners-3523f1b-0c0f7f18a78c44ae822277ad1fc650f9-an-owners-file-is-submitted-by-redhat

### DIFF
--- a/charts/redhat/redhat/redhat-prefixed-0c0f7f18a78c44ae822277ad1fc650f9-1/OWNERS
+++ b/charts/redhat/redhat/redhat-prefixed-0c0f7f18a78c44ae822277ad1fc650f9-1/OWNERS
@@ -1,0 +1,10 @@
+chart:
+  name: redhat-prefixed-0c0f7f18a78c44ae822277ad1fc650f9-1
+  shortDescription: Test chart for testing chart submission workflows.
+publicPgpKey: null
+providerDelivery: false
+users:
+- githubUsername: jsm84
+vendor:
+  label: redhat
+  name: "Not Red Hat"


### PR DESCRIPTION
Test triggered by https://github.com/jsm84/openshift-helm-charts-dev/pull/1.