### PR TITLE
e2e-owners-3523f1b-734fc350eb1f49b5a6b054ec18746c66-an-owners-file-is-submitted-by-redhat

### DIFF
--- a/charts/redhat/redhat/redhat-prefixed-734fc350eb1f49b5a6b054ec18746c66-1/OWNERS
+++ b/charts/redhat/redhat/redhat-prefixed-734fc350eb1f49b5a6b054ec18746c66-1/OWNERS
@@ -1,0 +1,10 @@
+chart:
+  name: redhat-prefixed-734fc350eb1f49b5a6b054ec18746c66-1
+  shortDescription: Test chart for testing chart submission workflows.
+publicPgpKey: null
+providerDelivery: false
+users:
+- githubUsername: jsm84
+vendor:
+  label: redhat
+  name: "Red Hat"


### PR DESCRIPTION
Test triggered by https://github.com/jsm84/openshift-helm-charts-dev/pull/1.