### PR TITLE
e2e-owners-3523f1b-7430b0687fb64701b17312e9c302666c-an-owners-file-is-submitted-by-redhat

### DIFF
--- a/charts/redhat/notredhat/redhat-prefixed-7430b0687fb64701b17312e9c302666c-1/OWNERS
+++ b/charts/redhat/notredhat/redhat-prefixed-7430b0687fb64701b17312e9c302666c-1/OWNERS
@@ -1,0 +1,10 @@
+chart:
+  name: redhat-prefixed-7430b0687fb64701b17312e9c302666c-1
+  shortDescription: Test chart for testing chart submission workflows.
+publicPgpKey: null
+providerDelivery: false
+users:
+- githubUsername: jsm84
+vendor:
+  label: notredhat
+  name: "Red Hat"


### PR DESCRIPTION
Test triggered by https://github.com/jsm84/openshift-helm-charts-dev/pull/1.