### PR TITLE
e2e-owners-3523f1b-617e964f647b4c0cb62ca86538ed8584-an-owners-file-is-submitted-by-redhat

### DIFF
--- a/charts/redhat/redhat/redhat-prefixed-617e964f647b4c0cb62ca86538ed8584-1/OWNERS
+++ b/charts/redhat/redhat/redhat-prefixed-617e964f647b4c0cb62ca86538ed8584-1/OWNERS
@@ -1,0 +1,10 @@
+chart:
+  name: redhat-prefixed-617e964f647b4c0cb62ca86538ed8584-1
+  shortDescription: Test chart for testing chart submission workflows.
+publicPgpKey: null
+providerDelivery: false
+users:
+- githubUsername: jsm84
+vendor:
+  label: redhat
+  name: "Not Red Hat"


### PR DESCRIPTION
Test triggered by https://github.com/jsm84/openshift-helm-charts-dev/pull/1.