### PR TITLE
e2e-owners-2603b60-6973df43b1de490bafc00c88ea9cbc70-an-owners-file-is-submitted-by-redhat

### DIFF
--- a/charts/redhat/redhat/missing-prefix-6973df43b1de490bafc00c88ea9cbc70-1/OWNERS
+++ b/charts/redhat/redhat/missing-prefix-6973df43b1de490bafc00c88ea9cbc70-1/OWNERS
@@ -1,0 +1,10 @@
+chart:
+  name: missing-prefix-6973df43b1de490bafc00c88ea9cbc70-1
+  shortDescription: Test chart for testing chart submission workflows.
+publicPgpKey: null
+providerDelivery: false
+users:
+- githubUsername: jsm84
+vendor:
+  label: redhat
+  name: "Red Hat"


### PR DESCRIPTION
Test triggered by https://github.com/jsm84/openshift-helm-charts-dev/pull/1.