### PR TITLE
e2e-owners-2603b60-cc2fba9328d14f86887ceb61fbea6079-an-owners-file-is-submitted-by-redhat

### DIFF
--- a/charts/redhat/notredhat/redhat-prefixed-cc2fba9328d14f86887ceb61fbea6079-1/OWNERS
+++ b/charts/redhat/notredhat/redhat-prefixed-cc2fba9328d14f86887ceb61fbea6079-1/OWNERS
@@ -1,0 +1,10 @@
+chart:
+  name: redhat-prefixed-cc2fba9328d14f86887ceb61fbea6079-1
+  shortDescription: Test chart for testing chart submission workflows.
+publicPgpKey: null
+providerDelivery: false
+users:
+- githubUsername: jsm84
+vendor:
+  label: notredhat
+  name: "Red Hat"


### PR DESCRIPTION
Test triggered by https://github.com/jsm84/openshift-helm-charts-dev/pull/1.