### PR TITLE
e2e-owners-2603b60-0154a9c27f734d4a8163018e4460481b-an-owners-file-is-submitted-by-redhat

### DIFF
--- a/charts/redhat/redhat/redhat-prefixed-0154a9c27f734d4a8163018e4460481b-1/OWNERS
+++ b/charts/redhat/redhat/redhat-prefixed-0154a9c27f734d4a8163018e4460481b-1/OWNERS
@@ -1,0 +1,10 @@
+chart:
+  name: redhat-prefixed-0154a9c27f734d4a8163018e4460481b-1
+  shortDescription: Test chart for testing chart submission workflows.
+publicPgpKey: null
+providerDelivery: false
+users:
+- githubUsername: jsm84
+vendor:
+  label: redhat
+  name: "Not Red Hat"


### PR DESCRIPTION
Test triggered by https://github.com/jsm84/openshift-helm-charts-dev/pull/1.