### PR TITLE
e2e-owners-2603b60-7055babb16b34984a668b0bff3381d77-an-owners-file-is-submitted-by-redhat

### DIFF
--- a/charts/redhat/notredhat/redhat-prefixed-7055babb16b34984a668b0bff3381d77-1/OWNERS
+++ b/charts/redhat/notredhat/redhat-prefixed-7055babb16b34984a668b0bff3381d77-1/OWNERS
@@ -1,0 +1,10 @@
+chart:
+  name: redhat-prefixed-7055babb16b34984a668b0bff3381d77-1
+  shortDescription: Test chart for testing chart submission workflows.
+publicPgpKey: null
+providerDelivery: false
+users:
+- githubUsername: jsm84
+vendor:
+  label: notredhat
+  name: "Red Hat"


### PR DESCRIPTION
Test triggered by https://github.com/jsm84/openshift-helm-charts-dev/pull/1.